### PR TITLE
Fix project content max characters limit

### DIFF
--- a/database/migrations/2024_04_11_141841_change_content_column_to_text.php
+++ b/database/migrations/2024_04_11_141841_change_content_column_to_text.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('project_contents', function (Blueprint $table) {
+            $table->text('content')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('project_contents', function (Blueprint $table) {
+            $table->string('content')->nullable()->change();
+        });
+    }
+};


### PR DESCRIPTION
Modified the ProjectContent content column in the database to be text instead of string. This allows more than 255 characters of text to be uploaded.