### PR TITLE
Add subtitle instead of dummy text

### DIFF
--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -26,7 +26,9 @@
                     <img class="increase" src="{{ asset('storage/' . $project->thumb) }}" alt="{{ $project->title }}">
                     <div class="ct-portfolio__item-text">
                         <h3>{{ $project->title }}</h3>
-                        <h4>Kent</h4>
+                        @if ($project->sub_title)
+                        <h4>{{ $project->sub_title }}</h4>
+                        @endif
                     </div>
                 </div>
             </a>


### PR DESCRIPTION
Replaced dummy text in index page portfolio with project subtitle. If no subtitle is present the h4 element will not display.